### PR TITLE
Implement gameover screen (issue #65) (#66)

### DIFF
--- a/MainGame/Gameover.py
+++ b/MainGame/Gameover.py
@@ -1,0 +1,112 @@
+import pygame
+import sys
+import Snake.snake as snake
+import Buttons.InstrucButton as Button
+import Pong.pong as pong
+import Invader.space_invaders as invader
+import Asteroids.asteroids as asteroids 
+import Breakout.breakout as breakout
+
+WIDTH = 1280
+HEIGHT = 720
+
+SNAKE_HIGHSCORE_FILE_PATH = 'MainGame/Snake/snakeScore.txt'
+INVADER_HIGHSCORE_FILE_PATH = 'MainGame/Invader/invaderScore.txt'
+ASTEROIDS_HIGHSCORE_FILE_PATH = 'MainGame/Asteroids/asteroidsScore.txt'
+PONG_HIGHSCORE_FILE_PATH = 'MainGame/Pong/pongScore.txt'
+
+class ScreenItem():
+    def __init__(self, x, y, image):
+        self.image = image
+        self.x = x
+        self.y = y
+        self.rect = self.image.get_rect(center=(self.x, self.y))
+
+    # Show the item
+    def update(self):
+        window = pygame.display.set_mode((WIDTH, HEIGHT))
+        window.blit(self.image, self.rect)
+
+    # Determine if mouse is interacting with item to perform further logic
+    def mouse_over_button(self, position):
+        if position[0] in range(self.rect.left, self.rect.right) and position[1] in range(self.rect.top, self.rect.bottom):
+            return True
+
+
+class gameover:
+
+    def gameOver(self, game):
+        running = True
+        while running:            
+            window = pygame.display.set_mode((WIDTH, HEIGHT))
+            window.fill("black")
+            PLAY_MOUSE_POS = pygame.mouse.get_pos()
+
+            score_font = pygame.font.Font("MainGame/Buttons/PressStart2P.ttf", 35)
+            title_font = pygame.font.Font("MainGame/Buttons/PressStart2P.ttf", 70)
+            button_font = pygame.font.Font("MainGame/Buttons/PressStart2P.ttf", 35)
+
+            OVER_TEXT = title_font.render("GAME OVER", True, "Red")
+
+            # Set text and score for each game
+            if game == "snake":
+                with open(SNAKE_HIGHSCORE_FILE_PATH, "r") as file:
+                    line = file.readline()  # scores are one line
+                    HIGHSCORE_TEXT = score_font.render("HIGHSCORE: " + line, True, "Yellow")
+            elif game == "pong":
+                with open(PONG_HIGHSCORE_FILE_PATH, "r") as file:
+                    line = file.readline()  
+                    HIGHSCORE_TEXT = score_font.render("HIGHSCORE: " + line, True, "Yellow")
+            elif game == "asteroids":
+                with open(ASTEROIDS_HIGHSCORE_FILE_PATH, "r") as file:
+                    line = file.readline() 
+                    HIGHSCORE_TEXT = score_font.render("HIGHSCORE: " + line, True, "Yellow")
+            elif game == "breakout":
+                HIGHSCORE_TEXT = score_font.render("well done!", True, "Yellow") # breakout has no high score   
+            elif game == "invader":
+                with open(INVADER_HIGHSCORE_FILE_PATH, "r") as file:
+                    line = file.readline() 
+                    HIGHSCORE_TEXT = score_font.render("HIGHSCORE: " + line, True, "Yellow")
+
+            # Show text
+            OVER_RECT = OVER_TEXT.get_rect(center=(640, 300))
+            window.blit(OVER_TEXT, OVER_RECT)
+            
+            HIGHSCORE_RECT = HIGHSCORE_TEXT.get_rect(center=(640, 400))
+            window.blit(HIGHSCORE_TEXT, HIGHSCORE_RECT)
+
+            # Navigation buttons
+            PLAY_BUTTON = Button.Button(image=None, pos=(860, 550), text_input="PLAY AGAIN", font=button_font, base_color="White", hovering_color="Green")
+            PLAY_BUTTON.changeColor(PLAY_MOUSE_POS)
+            PLAY_BUTTON.update(window)
+            QUIT_BUTTON = Button.Button(image=None, pos=(380, 550), text_input="MENU", font=button_font, base_color="White", hovering_color="Green")
+            QUIT_BUTTON.changeColor(PLAY_MOUSE_POS)
+            QUIT_BUTTON.update(window)
+
+            # Check for clicks
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    # x button exits the game window
+                    pygame.display.quit()
+                    sys.exit()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if PLAY_BUTTON.checkForInput(PLAY_MOUSE_POS):
+                        # Go to requested game
+                        if game == "snake":
+                            snake_obj = snake.snake_game()
+                            snake_obj.start_game()
+                        elif game == "pong":
+                            pong_obj = pong.PongGame()
+                            pong_obj.start_game()
+                        elif game == "asteroids":
+                            asteroids.start_asteroids()
+                        elif game == "breakout":
+                            breakout.start_breakout()
+                        elif game == "invader":
+                            invader.main()
+                            
+                        
+                    elif QUIT_BUTTON.checkForInput(PLAY_MOUSE_POS):
+                        running = False
+
+            pygame.display.update()

--- a/MainGame/Invader/space_invaders.py
+++ b/MainGame/Invader/space_invaders.py
@@ -2,6 +2,7 @@ from time import time
 import pygame
 import os
 import random
+import Gameover
 pygame.font.init()
 
 WIDTH = 1280
@@ -235,6 +236,11 @@ def main():
             game_over = True
             set_high_score(score)
             game_over_clock += 1
+
+            # goes to game over screen
+            pygame.display.set_caption("Game Over")
+            Gameover.gameover().gameOver("invader")
+
             break
 
         if game_over:

--- a/MainGame/Pong/pong.py
+++ b/MainGame/Pong/pong.py
@@ -2,6 +2,7 @@ from os import environ
 environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 import pygame
 import random
+import Gameover
 
 pygame.init()
 
@@ -152,6 +153,11 @@ class PongGame:
                 set_high_score(self.score_player)
                 game_over = True
                 break_loops = True
+
+                # goes to game over screen
+                pygame.display.set_caption("Game Over")
+                Gameover.gameover().gameOver("pong")
+
                 pygame.display.set_caption("Arcade Menu")
 
             # Updating the screen on each loop, keeping assets updated

--- a/MainGame/Snake/snake.py
+++ b/MainGame/Snake/snake.py
@@ -3,6 +3,7 @@ environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 import pygame
 import random
 import math
+import Gameover
 from enum import Enum
 from collections import namedtuple
 
@@ -54,7 +55,7 @@ SNAKE_SPEED = 10
 WINDOW_WIDTH = 1280
 WINDOW_HEIGHT = 720
 STARTING_SIZE = 3
-SNAKE_LOOPING = True # Change to false if you want the snake to die upon hitting a wall
+SNAKE_LOOPING = False # Change to false if you want the snake to die upon hitting a wall
 
 # Colours
 WHITE = (255, 255, 255)
@@ -308,9 +309,11 @@ class snake_game:
                     break_loops = True
                     pygame.display.set_caption("Arcade Menu")
         
+    
         while break_loops == False:
-            self.display.blit(game_over_screen, (0, 0))
-            pygame.display.flip()
+            # goes to game over screen
+            pygame.display.set_caption("Game Over")
+            Gameover.gameover().gameOver("snake")
             
             # Wait 1 second after the game is over before accepting inputs in order to combat accidental keypresses
             for event in pygame.event.get():    


### PR DESCRIPTION
* feat: added a game over screen file that should display after each game. Display a 'Game Over' text along with high score and navigation options

* feat: implemented game over screen for pong

* feat: implemented game over screen for space invaders

* fix: turned off snake looping to allow easier testing

* refactor: taken game over message outside of individual game if-loops since it is redundant

* fix: changed gameover screen exit method - instead of going back to previous screen, x button now closes the window entirely

* feat: added game over screen for snake